### PR TITLE
Skip authenticating with Discord if registered

### DIFF
--- a/src/routes/auth/callback/osu/+server.ts
+++ b/src/routes/auth/callback/osu/+server.ts
@@ -11,5 +11,8 @@ export const GET = (async (event) => {
   }
 
   let redirectUrl = await caller.auth.handleOsuAuth(code);
+  if (redirectUrl === "/") {
+    await caller.auth.updateUser()
+  }
   throw redirect(302, redirectUrl);
 }) satisfies RequestHandler;


### PR DESCRIPTION
`getDiscordProfile` will likely be reused soon to deal with the process of changing discord accounts
I chose to keep `getProfiles`

okay I won't lie I'm not _super_ satisfied because `ctx.cookies.set('session'...` is used three different times in the file, but I didn't feel the need to rewrite lots of code only for the sake of not repeating, I think it's good enough