### PR TITLE
Display the correct tourney creation price when using free services

### DIFF
--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -247,7 +247,21 @@
             </ListBox>
           </div>
           <h4>
-            Total Cost: {format.price(
+            Total Cost: {#if selectedServices.length && data.user.freeServicesLeft > 0}
+              <s class="text-sm text-slate-300">
+                {format.price(
+                    selectedServices.reduce((total, service) => {
+                      return (
+                        total +
+                        services[service][
+                          createTournament.tournament?.type === 'Teams' ? 'teamsPrice' : 'soloPrice'
+                        ]
+                      );
+                    }, 0)
+                  )}
+                </s>
+            {/if}
+            {format.price(
               selectedServices.map((service) => services[service][
                 createTournament.tournament?.type === 'Teams' ? 'teamsPrice' : 'soloPrice'
               ])

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -248,13 +248,13 @@
           </div>
           <h4>
             Total Cost: {format.price(
-              selectedServices.reduce((total, service) => {
-                return (
-                  total +
-                  services[service][
-                    createTournament.tournament?.type === 'Teams' ? 'teamsPrice' : 'soloPrice'
-                  ]
-                );
+              selectedServices.map((service) => services[service][
+                createTournament.tournament?.type === 'Teams' ? 'teamsPrice' : 'soloPrice'
+              ])
+              .sort((a, b) => b - a)
+              .reduce((total, price, index) => {
+                if (data.user.freeServicesLeft > 0 && index === 1) {total = 0}
+                return (index < data.user.freeServicesLeft ? total : total + price)
               }, 0)
             )}
           </h4>
@@ -263,7 +263,7 @@
               ><b>Note:</b> As a new user, you've been given the ability to add 3 services for free.{data
                 .user.freeServicesLeft === 3
                 ? ''
-                : `You currently have ${data.user.freeServicesLeft} service${
+                : ` You currently have ${data.user.freeServicesLeft} service${
                     data.user.freeServicesLeft === 1 ? '' : 's'
                   } left.`}</span
             >


### PR DESCRIPTION
Prior to this PR, the sum of all selected services would be shown as the total cost
Now, the total cost reflects the actual cost, as it doesn't have the cost of the services that would be free for the user


https://user-images.githubusercontent.com/67872932/236951645-60c4e486-fec4-48da-bf3c-100a106870db.mp4

