### PR TITLE
Implemented rate limit middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,9 +43,7 @@ IPINFO_ACCESS_TOKEN=
 
 # {string}
 UPSTASH_API_KEY=
-
 # {string} URL of Redis instance provided by Upstash
 UPSTASH_REDIS_REST_URL=
-
 # {string}
 UPSTASH_REDIS_REST_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,12 @@ BUNNY_PASSWORD=
 
 # {string}
 IPINFO_ACCESS_TOKEN=
+
+# {string}
+UPSTASH_API_KEY=
+
+# {string} URL of Redis instance provided by Upstash
+UPSTASH_REDIS_REST_URL=
+
+# {string}
+UPSTASH_REDIS_REST_TOKEN=

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
     "@trpc/client": "^10.45.2",
     "@trpc/server": "^10.45.2",
     "@typeschema/valibot": "^0.13.4",
+    "@upstash/ratelimit": "^1.0.1",
+    "@upstash/redis": "^1.28.4",
     "discord-oauth2": "^2.12.1",
     "drizzle-orm": "^0.30.1",
     "highlight.js": "^11.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ dependencies:
   '@typeschema/valibot':
     specifier: ^0.13.4
     version: 0.13.4(valibot@0.30.0)
+  '@upstash/ratelimit':
+    specifier: ^1.0.1
+    version: 1.0.1
+  '@upstash/redis':
+    specifier: ^1.28.4
+    version: 1.28.4
   discord-oauth2:
     specifier: ^2.12.1
     version: 2.12.1
@@ -1483,6 +1489,25 @@ packages:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: true
 
+  /@upstash/core-analytics@0.0.7:
+    resolution: {integrity: sha512-lC2j5efqb1haX/fpTGaPUx1rue1WUkOZBVHDzCB7eMIVsRdFFp4xiHtyH/G9omiR1zj39fU5SCTWFiKJH3KOpw==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@upstash/redis': 1.28.4
+    dev: false
+
+  /@upstash/ratelimit@1.0.1:
+    resolution: {integrity: sha512-G9LZ7idhlkuYknbUngCB3qzd7QnkK1xDkFG5jRtEJZuOUS5UKJ0UTKbhalCtp39eX2wu2Ubv8W7HCeaJQOWM0A==}
+    dependencies:
+      '@upstash/core-analytics': 0.0.7
+    dev: false
+
+  /@upstash/redis@1.28.4:
+    resolution: {integrity: sha512-UalkSAny/dz1m8giEhD3Y5ru1o+CPHI32wFyS3MyzDzj2TRvEN+lTw+mPwi20ojk0H2gs8TBW3qsrvwuLLy+pA==}
+    dependencies:
+      crypto-js: 4.2.0
+    dev: false
+
   /@vercel/nft@0.26.4:
     resolution: {integrity: sha512-j4jCOOXke2t8cHZCIxu1dzKLHLcFmYzC3yqAK6MfZznOL1QIJKd0xcFsXK3zcqzU7ScsE2zWkiMMNHGMHgp+FA==}
     engines: {node: '>=16'}
@@ -1907,6 +1932,10 @@ packages:
       shebang-command: 2.0.0
       which: 2.0.2
     dev: true
+
+  /crypto-js@4.2.0:
+    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    dev: false
 
   /css-tree@2.3.1:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}

--- a/scripts/env.ts
+++ b/scripts/env.ts
@@ -34,7 +34,10 @@ const serverEnvSchema = v.object({
   IPINFO_ACCESS_TOKEN: nonEmptyStringSchema,
   DATABASE_URL: nonEmptyStringSchema,
   OWNER: v.number('be a number', [v.integer('be an integer')]),
-  TESTERS: v.array(v.number('be a number', [v.integer('be an integer')]), 'be an array')
+  TESTERS: v.array(v.number('be a number', [v.integer('be an integer')]), 'be an array'),
+  UPSTASH_API_KEY: nonEmptyStringSchema,
+  UPSTASH_REDIS_REST_URL: nonEmptyStringSchema,
+  UPSTASH_REDIS_REST_TOKEN: nonEmptyStringSchema
 });
 
 export function getEnv() {
@@ -58,7 +61,10 @@ export function getEnv() {
     IPINFO_ACCESS_TOKEN: process.env.IPINFO_ACCESS_TOKEN,
     DATABASE_URL: process.env.DATABASE_URL,
     OWNER: Number(process.env.OWNER),
-    TESTERS: (JSON.parse(process.env.TESTERS || '[]') as string[]).map((id) => Number(id))
+    TESTERS: (JSON.parse(process.env.TESTERS || '[]') as string[]).map((id) => Number(id)),
+    UPSTASH_API_KEY: process.env.UPSTASH_API_KEY,
+    UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+    UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN
   });
 
   if (!parsed.success) {

--- a/scripts/env.ts
+++ b/scripts/env.ts
@@ -34,10 +34,7 @@ const serverEnvSchema = v.object({
   IPINFO_ACCESS_TOKEN: nonEmptyStringSchema,
   DATABASE_URL: nonEmptyStringSchema,
   OWNER: v.number('be a number', [v.integer('be an integer')]),
-  TESTERS: v.array(v.number('be a number', [v.integer('be an integer')]), 'be an array'),
-  UPSTASH_API_KEY: nonEmptyStringSchema,
-  UPSTASH_REDIS_REST_URL: nonEmptyStringSchema,
-  UPSTASH_REDIS_REST_TOKEN: nonEmptyStringSchema
+  TESTERS: v.array(v.number('be a number', [v.integer('be an integer')]), 'be an array')
 });
 
 export function getEnv() {
@@ -61,10 +58,7 @@ export function getEnv() {
     IPINFO_ACCESS_TOKEN: process.env.IPINFO_ACCESS_TOKEN,
     DATABASE_URL: process.env.DATABASE_URL,
     OWNER: Number(process.env.OWNER),
-    TESTERS: (JSON.parse(process.env.TESTERS || '[]') as string[]).map((id) => Number(id)),
-    UPSTASH_API_KEY: process.env.UPSTASH_API_KEY,
-    UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
-    UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN
+    TESTERS: (JSON.parse(process.env.TESTERS || '[]') as string[]).map((id) => Number(id))
   });
 
   if (!parsed.success) {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -10,7 +10,7 @@ import { and, eq, not, sql } from 'drizzle-orm';
 import { discordMainAuth, osuAuth, discordMainAuthOptions } from '$lib/server/constants';
 import { unionAll } from 'drizzle-orm/pg-core';
 import { upsertDiscordUser, upsertOsuUser } from '$lib/server/helpers/auth';
-import { ratelimit } from '$lib/server/helpers/consts';
+import { ratelimit } from '$lib/server/ratelimit';
 import type DiscordOAuth2 from 'discord-oauth2';
 import type { Token } from 'osu-web.js';
 import type { Cookies } from '@sveltejs/kit';

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -12,7 +12,10 @@ import {
   DATABASE_URL,
   TESTERS,
   ENV,
-  IPINFO_ACCESS_TOKEN
+  IPINFO_ACCESS_TOKEN,
+  UPSTASH_API_KEY,
+  UPSTASH_REDIS_REST_URL,
+  UPSTASH_REDIS_REST_TOKEN
 } from '$env/static/private';
 import { clientEnvSchema, clientEnv, nonEmptyStringSchema, parseEnv } from '../env';
 
@@ -37,7 +40,10 @@ const serverEnvSchema = v.object({
   IPINFO_ACCESS_TOKEN: nonEmptyStringSchema,
   DATABASE_URL: nonEmptyStringSchema,
   OWNER: v.number('be a number', [v.integer('be an integer')]),
-  TESTERS: v.array(v.number('be a number', [v.integer('be an integer')]), 'be an array')
+  TESTERS: v.array(v.number('be a number', [v.integer('be an integer')]), 'be an array'),
+  UPSTASH_API_KEY: nonEmptyStringSchema,
+  UPSTASH_REDIS_REST_URL: nonEmptyStringSchema,
+  UPSTASH_REDIS_REST_TOKEN: nonEmptyStringSchema
 });
 
 const serverEnv = {
@@ -54,7 +60,10 @@ const serverEnv = {
   IPINFO_ACCESS_TOKEN,
   DATABASE_URL,
   OWNER: Number(OWNER),
-  TESTERS: (JSON.parse(TESTERS || '[]') as string[]).map((id) => Number(id))
+  TESTERS: (JSON.parse(TESTERS || '[]') as string[]).map((id) => Number(id)),
+  UPSTASH_API_KEY,
+  UPSTASH_REDIS_REST_URL,
+  UPSTASH_REDIS_REST_TOKEN
 };
 
 const env = parseEnv(serverEnvSchema, serverEnv);

--- a/src/lib/server/procedures/users.ts
+++ b/src/lib/server/procedures/users.ts
@@ -21,6 +21,7 @@ import { getSession } from '../helpers/api';
 import { TRPCError } from '@trpc/server';
 import { alias, unionAll } from 'drizzle-orm/pg-core';
 import type { SQL } from 'drizzle-orm';
+import { rateLimitMiddleware } from '$trpc/middleware';
 
 const getUser = t.procedure
   .input(
@@ -180,6 +181,7 @@ const getUser = t.procedure
   });
 
 const searchUser = t.procedure
+  .use(rateLimitMiddleware)
   .input(
     wrap(
       v.object({

--- a/src/lib/server/procedures/users.ts
+++ b/src/lib/server/procedures/users.ts
@@ -20,8 +20,8 @@ import { positiveIntSchema } from '$lib/schemas';
 import { getSession } from '../helpers/api';
 import { TRPCError } from '@trpc/server';
 import { alias, unionAll } from 'drizzle-orm/pg-core';
-import type { SQL } from 'drizzle-orm';
 import { rateLimitMiddleware } from '$trpc/middleware';
+import type { SQL } from 'drizzle-orm';
 
 const getUser = t.procedure
   .input(

--- a/src/lib/server/ratelimit.ts
+++ b/src/lib/server/ratelimit.ts
@@ -7,5 +7,5 @@ export const ratelimit = new Ratelimit({
     url: env.UPSTASH_REDIS_REST_URL,
     token: env.UPSTASH_REDIS_REST_TOKEN
   }),
-  limiter: Ratelimit.slidingWindow(1, '10 s')
+  limiter: Ratelimit.slidingWindow(10, '1 s')
 });

--- a/src/lib/server/ratelimit.ts
+++ b/src/lib/server/ratelimit.ts
@@ -1,6 +1,6 @@
+import env from '$lib/server/env';
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
-import env from '$lib/server/env';
 
 export const ratelimit = new Ratelimit({
   redis: new Redis({

--- a/src/lib/server/ratelimit.ts
+++ b/src/lib/server/ratelimit.ts
@@ -1,0 +1,11 @@
+import { Ratelimit } from '@upstash/ratelimit';
+import { Redis } from '@upstash/redis';
+import env from '$lib/server/env';
+
+export const ratelimit = new Ratelimit({
+  redis: new Redis({
+    url: env.UPSTASH_REDIS_REST_URL,
+    token: env.UPSTASH_REDIS_REST_TOKEN
+  }),
+  limiter: Ratelimit.slidingWindow(1, '10 s')
+});

--- a/src/lib/server/trpc/context.ts
+++ b/src/lib/server/trpc/context.ts
@@ -1,12 +1,19 @@
 import type { RequestEvent } from '@sveltejs/kit';
 import type { inferAsyncReturnType } from '@trpc/server';
 
-export async function createContext({ request, cookies, fetch, url }: RequestEvent) {
+export async function createContext({
+  request,
+  cookies,
+  fetch,
+  url,
+  getClientAddress
+}: RequestEvent) {
   return {
     request,
     fetch,
     url,
-    cookies
+    cookies,
+    getClientAddress
   };
 }
 

--- a/src/lib/server/trpc/middleware.ts
+++ b/src/lib/server/trpc/middleware.ts
@@ -12,9 +12,7 @@
 // import { verifyJWT } from '$lib/jwt';
 import { t } from '$trpc';
 import { TRPCError } from '@trpc/server';
-import { Ratelimit } from '@upstash/ratelimit';
-import { Redis } from '@upstash/redis';
-import { getEnv } from '../../../../scripts/env';
+import { ratelimit } from '$lib/server/ratelimit';
 // import { findFirstOrThrow, pick } from '$lib/server/utils';
 // import type { SessionUser } from '$types';
 // import type { Context } from '$trpc/context';
@@ -179,14 +177,6 @@ import { getEnv } from '../../../../scripts/env';
 //     });
 //   }
 // );
-
-const ratelimit = new Ratelimit({
-  redis: new Redis({
-    url: getEnv().UPSTASH_REDIS_REST_URL,
-    token: getEnv().UPSTASH_REDIS_REST_TOKEN
-  }),
-  limiter: Ratelimit.slidingWindow(1, '10 s')
-});
 
 export const rateLimitMiddleware = t.middleware(
   async ({ path, next, ctx: { getClientAddress } }) => {


### PR DESCRIPTION
Resolves #24 

This PR introduces tRPC rate limit middleware that can be attached to any procedure via `.use()`

```
const ratelimit = new Ratelimit({
  redis: new Redis({
    url: getEnv().UPSTASH_REDIS_REST_URL,
    token: getEnv().UPSTASH_REDIS_REST_TOKEN
  }),
  limiter: Ratelimit.slidingWindow(1, '10 s')
});
```

Limitations are set in `Ratelimit.slidingWindow` arguments, where (1, '10 s') stands for "1 request per 10 seconds".

Video demonstration:

https://github.com/Kyoso-Team/kyoso/assets/96246908/d1bbf674-dbfa-4e35-9499-369f36a0a0d7

**Note**: Upstash doesn't allow to rate limit any other Redis instances than provided by Upstash themselves, so you'll have to provide your own Upstash Redis credentials. Alternatively we can create a shared development instance and use it instead

