### PR TITLE
Added citext pg type and changed some fields from varchar/text to citext

### DIFF
--- a/migrations/0011_smart_red_wolf.sql
+++ b/migrations/0011_smart_red_wolf.sql
@@ -1,0 +1,2 @@
+-- Custom SQL migration file, put you code below! --
+CREATE EXTENSION IF NOT EXISTS citext;

--- a/migrations/0012_square_the_watchers.sql
+++ b/migrations/0012_square_the_watchers.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "discord_user" ALTER COLUMN "username" SET DATA TYPE citext;--> statement-breakpoint
+ALTER TABLE "osu_user" ALTER COLUMN "username" SET DATA TYPE citext;--> statement-breakpoint
+ALTER TABLE "round" ALTER COLUMN "name" SET DATA TYPE citext;--> statement-breakpoint
+ALTER TABLE "tournament" ALTER COLUMN "name" SET DATA TYPE citext;--> statement-breakpoint
+ALTER TABLE "staff_role" ALTER COLUMN "name" SET DATA TYPE citext;

--- a/migrations/meta/0011_snapshot.json
+++ b/migrations/meta/0011_snapshot.json
@@ -1,0 +1,1259 @@
+{
+  "id": "0ce46668-e1c9-45ec-8b00-e5ee13200570",
+  "prevId": "cb94bc24-34a0-48cc-86e7-c786c8f925a8",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "ban": {
+      "name": "ban",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lift_at": {
+          "name": "lift_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoke_reason": {
+          "name": "revoke_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_to_user_id": {
+          "name": "issued_to_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_ban_issued_to_user_id_issued_at": {
+          "name": "idx_ban_issued_to_user_id_issued_at",
+          "columns": [
+            "issued_to_user_id",
+            "issued_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ban_issued_by_user_id_user_id_fk": {
+          "name": "ban_issued_by_user_id_user_id_fk",
+          "tableFrom": "ban",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "ban_revoked_by_user_id_user_id_fk": {
+          "name": "ban_revoked_by_user_id_user_id_fk",
+          "tableFrom": "ban",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "ban_issued_to_user_id_user_id_fk": {
+          "name": "ban_issued_to_user_id_user_id_fk",
+          "tableFrom": "ban",
+          "columnsFrom": [
+            "issued_to_user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "country": {
+      "name": "country",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "char(2)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(35)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "discord_user": {
+      "name": "discord_user",
+      "schema": "",
+      "columns": {
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(19)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_hash": {
+          "name": "message_hash",
+          "type": "char(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uni_notification_message_hash": {
+          "name": "uni_notification_message_hash",
+          "columns": [
+            "message_hash"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "osu_badge": {
+      "name": "osu_badge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "img_file_name": {
+          "name": "img_file_name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "udx_osu_badge_img_file_name": {
+          "name": "udx_osu_badge_img_file_name",
+          "columns": [
+            "img_file_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "osu_user": {
+      "name": "osu_user",
+      "schema": "",
+      "columns": {
+        "osu_user_id": {
+          "name": "osu_user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restricted": {
+          "name": "restricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "global_std_rank": {
+          "name": "global_std_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "udx_osu_user_username": {
+          "name": "udx_osu_user_username",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "osu_user_country_code_country_code_fk": {
+          "name": "osu_user_country_code_country_code_fk",
+          "tableFrom": "osu_user",
+          "columnsFrom": [
+            "country_code"
+          ],
+          "tableTo": "country",
+          "columnsTo": [
+            "code"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "osu_user_awarded_badge": {
+      "name": "osu_user_awarded_badge",
+      "schema": "",
+      "columns": {
+        "osu_user_id": {
+          "name": "osu_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "osu_badge_id": {
+          "name": "osu_badge_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "awarded_at": {
+          "name": "awarded_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_osu_user_awarded_badge_osu_user_id": {
+          "name": "idx_osu_user_awarded_badge_osu_user_id",
+          "columns": [
+            "osu_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "osu_user_awarded_badge_osu_user_id_osu_user_osu_user_id_fk": {
+          "name": "osu_user_awarded_badge_osu_user_id_osu_user_osu_user_id_fk",
+          "tableFrom": "osu_user_awarded_badge",
+          "columnsFrom": [
+            "osu_user_id"
+          ],
+          "tableTo": "osu_user",
+          "columnsTo": [
+            "osu_user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "osu_user_awarded_badge_osu_badge_id_osu_badge_id_fk": {
+          "name": "osu_user_awarded_badge_osu_badge_id_osu_badge_id_fk",
+          "tableFrom": "osu_user_awarded_badge",
+          "columnsFrom": [
+            "osu_badge_id"
+          ],
+          "tableTo": "osu_badge",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "osu_user_awarded_badge_osu_user_id_osu_badge_id_pk": {
+          "name": "osu_user_awarded_badge_osu_user_id_osu_badge_id_pk",
+          "columns": [
+            "osu_user_id",
+            "osu_badge_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "update_cookie": {
+          "name": "update_cookie",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_metadata": {
+          "name": "ip_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expired": {
+          "name": "expired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_session_id_expired": {
+          "name": "idx_session_id_expired",
+          "columns": [
+            "id",
+            "expired"
+          ],
+          "isUnique": false
+        },
+        "idx_session_user_id_expired": {
+          "name": "idx_session_user_id_expired",
+          "columns": [
+            "user_id",
+            "expired"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_api_data_at": {
+          "name": "updated_api_data_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "admin": {
+          "name": "admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_host": {
+          "name": "approved_host",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "osu_user_id": {
+          "name": "osu_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(19)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "udx_user_osu_user_id": {
+          "name": "udx_user_osu_user_id",
+          "columns": [
+            "osu_user_id"
+          ],
+          "isUnique": true
+        },
+        "udx_user_discord_user_id": {
+          "name": "udx_user_discord_user_id",
+          "columns": [
+            "discord_user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_osu_user_id_osu_user_osu_user_id_fk": {
+          "name": "user_osu_user_id_osu_user_osu_user_id_fk",
+          "tableFrom": "user",
+          "columnsFrom": [
+            "osu_user_id"
+          ],
+          "tableTo": "osu_user",
+          "columnsTo": [
+            "osu_user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "user_discord_user_id_discord_user_discord_user_id_fk": {
+          "name": "user_discord_user_id_discord_user_discord_user_id_fk",
+          "tableFrom": "user",
+          "columnsFrom": [
+            "discord_user_id"
+          ],
+          "tableTo": "discord_user",
+          "columnsTo": [
+            "discord_user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uni_user_api_key": {
+          "name": "uni_user_api_key",
+          "columns": [
+            "api_key"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "user_notification": {
+      "name": "user_notification",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_user_notification_notification_id": {
+          "name": "idx_user_notification_notification_id",
+          "columns": [
+            "notification_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_notification_user_id_notified_at": {
+          "name": "idx_user_notification_user_id_notified_at",
+          "columns": [
+            "user_id",
+            "notified_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_notification_user_id_user_id_fk": {
+          "name": "user_notification_user_id_user_id_fk",
+          "tableFrom": "user_notification",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "user_notification_notification_id_notification_id_fk": {
+          "name": "user_notification_notification_id_notification_id_fk",
+          "tableFrom": "user_notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "tableTo": "notification",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_notification_user_id_notification_id_pk": {
+          "name": "user_notification_user_id_notification_id_pk",
+          "columns": [
+            "user_id",
+            "notification_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "round": {
+      "name": "round",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_star_rating": {
+          "name": "target_star_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playtesting_pool": {
+          "name": "playtesting_pool",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publish_pool": {
+          "name": "publish_pool",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publish_schedules": {
+          "name": "publish_schedules",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publish_stats": {
+          "name": "publish_stats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "round_stage_id_stage_id_fk": {
+          "name": "round_stage_id_stage_id_fk",
+          "tableFrom": "round",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "tableTo": "stage",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "round_tournament_id_tournament_id_fk": {
+          "name": "round_tournament_id_tournament_id_fk",
+          "tableFrom": "round",
+          "columnsFrom": [
+            "tournament_id"
+          ],
+          "tableTo": "tournament",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uni_round_name_tournament_id": {
+          "name": "uni_round_name_tournament_id",
+          "columns": [
+            "name",
+            "tournament_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "stage": {
+      "name": "stage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "stage_format",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_main_stage": {
+          "name": "is_main_stage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stage_tournament_id_tournament_id_fk": {
+          "name": "stage_tournament_id_tournament_id_fk",
+          "tableFrom": "stage",
+          "columnsFrom": [
+            "tournament_id"
+          ],
+          "tableTo": "tournament",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uni_stage_tournament_id_format": {
+          "name": "uni_stage_tournament_id_format",
+          "columns": [
+            "tournament_id",
+            "format"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "tournament": {
+      "name": "tournament",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url_slug": {
+          "name": "url_slug",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acronym": {
+          "name": "acronym",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "tournament_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_metadata": {
+          "name": "logo_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_metadata": {
+          "name": "banner_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank_range": {
+          "name": "rank_range",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dates": {
+          "name": "dates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"other\":[]}'::jsonb"
+        },
+        "team_settings": {
+          "name": "team_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bws_values": {
+          "name": "bws_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "links": {
+          "name": "links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "referee_settings": {
+          "name": "referee_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"timerLength\":{\"pick\":120,\"ban\":120,\"protect\":120,\"ready\":120,\"start\":10},\"allow\":{\"doublePick\":false,\"doubleBan\":false,\"doubleProtect\":false},\"order\":{\"ban\":\"linear\",\"pick\":\"linear\",\"protect\":\"linear\"},\"alwaysForceNoFail\":true,\"banAndProtectCancelOut\":false,\"winCondition\":\"score\"}'::jsonb"
+        }
+      },
+      "indexes": {
+        "udx_tournament_url_slug": {
+          "name": "udx_tournament_url_slug",
+          "columns": [
+            "url_slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uni_tournament_name": {
+          "name": "uni_tournament_name",
+          "columns": [
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "staff_member": {
+      "name": "staff_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "joined_staff_at": {
+          "name": "joined_staff_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "staff_member_user_id_user_id_fk": {
+          "name": "staff_member_user_id_user_id_fk",
+          "tableFrom": "staff_member",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "staff_member_tournament_id_tournament_id_fk": {
+          "name": "staff_member_tournament_id_tournament_id_fk",
+          "tableFrom": "staff_member",
+          "columnsFrom": [
+            "tournament_id"
+          ],
+          "tableTo": "tournament",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uni_staff_member_user_id_tournament_id": {
+          "name": "uni_staff_member_user_id_tournament_id",
+          "columns": [
+            "user_id",
+            "tournament_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "staff_member_role": {
+      "name": "staff_member_role",
+      "schema": "",
+      "columns": {
+        "staff_member_id": {
+          "name": "staff_member_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staff_role_id": {
+          "name": "staff_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "staff_member_role_staff_member_id_staff_member_id_fk": {
+          "name": "staff_member_role_staff_member_id_staff_member_id_fk",
+          "tableFrom": "staff_member_role",
+          "columnsFrom": [
+            "staff_member_id"
+          ],
+          "tableTo": "staff_member",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "staff_member_role_staff_role_id_staff_role_id_fk": {
+          "name": "staff_member_role_staff_role_id_staff_role_id_fk",
+          "tableFrom": "staff_member_role",
+          "columnsFrom": [
+            "staff_role_id"
+          ],
+          "tableTo": "staff_role",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "staff_member_role_staff_member_id_staff_role_id_pk": {
+          "name": "staff_member_role_staff_member_id_staff_role_id_pk",
+          "columns": [
+            "staff_member_id",
+            "staff_role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "staff_role": {
+      "name": "staff_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "staff_color",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'slate'"
+        },
+        "order": {
+          "name": "order",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "staff_permission[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": []
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "staff_role_tournament_id_tournament_id_fk": {
+          "name": "staff_role_tournament_id_tournament_id_fk",
+          "tableFrom": "staff_role",
+          "columnsFrom": [
+            "tournament_id"
+          ],
+          "tableTo": "tournament",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uni_staff_role_name_tournament_id": {
+          "name": "uni_staff_role_name_tournament_id",
+          "columns": [
+            "name",
+            "tournament_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    }
+  },
+  "enums": {
+    "staff_color": {
+      "name": "staff_color",
+      "values": {
+        "slate": "slate",
+        "gray": "gray",
+        "red": "red",
+        "orange": "orange",
+        "yellow": "yellow",
+        "lime": "lime",
+        "green": "green",
+        "emerald": "emerald",
+        "cyan": "cyan",
+        "blue": "blue",
+        "indigo": "indigo",
+        "purple": "purple",
+        "fuchsia": "fuchsia",
+        "pink": "pink"
+      }
+    },
+    "staff_permission": {
+      "name": "staff_permission",
+      "values": {
+        "host": "host",
+        "debug": "debug",
+        "manage_tournament": "manage_tournament",
+        "manage_assets": "manage_assets",
+        "manage_regs": "manage_regs",
+        "manage_pool_structure": "manage_pool_structure",
+        "view_pool_suggestions": "view_pool_suggestions",
+        "create_pool_suggestions": "create_pool_suggestions",
+        "delete_pool_suggestions": "delete_pool_suggestions",
+        "view_pooled_maps": "view_pooled_maps",
+        "manage_pooled_maps": "manage_pooled_maps",
+        "view_feedback": "view_feedback",
+        "can_playtest": "can_playtest",
+        "can_submit_replays": "can_submit_replays",
+        "view_matches": "view_matches",
+        "manage_matches": "manage_matches",
+        "ref_matches": "ref_matches",
+        "commentate_matches": "commentate_matches",
+        "stream_matches": "stream_matches",
+        "manage_stats": "manage_stats",
+        "can_play": "can_play"
+      }
+    },
+    "stage_format": {
+      "name": "stage_format",
+      "values": {
+        "groups": "groups",
+        "swiss": "swiss",
+        "qualifiers": "qualifiers",
+        "single_elim": "single_elim",
+        "double_elim": "double_elim",
+        "battle_royale": "battle_royale"
+      }
+    },
+    "tournament_type": {
+      "name": "tournament_type",
+      "values": {
+        "teams": "teams",
+        "draft": "draft",
+        "solo": "solo"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/0012_snapshot.json
+++ b/migrations/meta/0012_snapshot.json
@@ -1,0 +1,1259 @@
+{
+  "id": "a1c92daf-4644-4e12-8a5d-93fad2aa1b72",
+  "prevId": "0ce46668-e1c9-45ec-8b00-e5ee13200570",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "ban": {
+      "name": "ban",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lift_at": {
+          "name": "lift_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoke_reason": {
+          "name": "revoke_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_to_user_id": {
+          "name": "issued_to_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_ban_issued_to_user_id_issued_at": {
+          "name": "idx_ban_issued_to_user_id_issued_at",
+          "columns": [
+            "issued_to_user_id",
+            "issued_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ban_issued_by_user_id_user_id_fk": {
+          "name": "ban_issued_by_user_id_user_id_fk",
+          "tableFrom": "ban",
+          "tableTo": "user",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ban_revoked_by_user_id_user_id_fk": {
+          "name": "ban_revoked_by_user_id_user_id_fk",
+          "tableFrom": "ban",
+          "tableTo": "user",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ban_issued_to_user_id_user_id_fk": {
+          "name": "ban_issued_to_user_id_user_id_fk",
+          "tableFrom": "ban",
+          "tableTo": "user",
+          "columnsFrom": [
+            "issued_to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "country": {
+      "name": "country",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "char(2)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(35)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "discord_user": {
+      "name": "discord_user",
+      "schema": "",
+      "columns": {
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(19)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_hash": {
+          "name": "message_hash",
+          "type": "char(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uni_notification_message_hash": {
+          "name": "uni_notification_message_hash",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_hash"
+          ]
+        }
+      }
+    },
+    "osu_badge": {
+      "name": "osu_badge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "img_file_name": {
+          "name": "img_file_name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "udx_osu_badge_img_file_name": {
+          "name": "udx_osu_badge_img_file_name",
+          "columns": [
+            "img_file_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "osu_user": {
+      "name": "osu_user",
+      "schema": "",
+      "columns": {
+        "osu_user_id": {
+          "name": "osu_user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restricted": {
+          "name": "restricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "global_std_rank": {
+          "name": "global_std_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "udx_osu_user_username": {
+          "name": "udx_osu_user_username",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "osu_user_country_code_country_code_fk": {
+          "name": "osu_user_country_code_country_code_fk",
+          "tableFrom": "osu_user",
+          "tableTo": "country",
+          "columnsFrom": [
+            "country_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "osu_user_awarded_badge": {
+      "name": "osu_user_awarded_badge",
+      "schema": "",
+      "columns": {
+        "osu_user_id": {
+          "name": "osu_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "osu_badge_id": {
+          "name": "osu_badge_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "awarded_at": {
+          "name": "awarded_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_osu_user_awarded_badge_osu_user_id": {
+          "name": "idx_osu_user_awarded_badge_osu_user_id",
+          "columns": [
+            "osu_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "osu_user_awarded_badge_osu_user_id_osu_user_osu_user_id_fk": {
+          "name": "osu_user_awarded_badge_osu_user_id_osu_user_osu_user_id_fk",
+          "tableFrom": "osu_user_awarded_badge",
+          "tableTo": "osu_user",
+          "columnsFrom": [
+            "osu_user_id"
+          ],
+          "columnsTo": [
+            "osu_user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "osu_user_awarded_badge_osu_badge_id_osu_badge_id_fk": {
+          "name": "osu_user_awarded_badge_osu_badge_id_osu_badge_id_fk",
+          "tableFrom": "osu_user_awarded_badge",
+          "tableTo": "osu_badge",
+          "columnsFrom": [
+            "osu_badge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "osu_user_awarded_badge_osu_user_id_osu_badge_id_pk": {
+          "name": "osu_user_awarded_badge_osu_user_id_osu_badge_id_pk",
+          "columns": [
+            "osu_user_id",
+            "osu_badge_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "update_cookie": {
+          "name": "update_cookie",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_metadata": {
+          "name": "ip_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expired": {
+          "name": "expired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_session_id_expired": {
+          "name": "idx_session_id_expired",
+          "columns": [
+            "id",
+            "expired"
+          ],
+          "isUnique": false
+        },
+        "idx_session_user_id_expired": {
+          "name": "idx_session_user_id_expired",
+          "columns": [
+            "user_id",
+            "expired"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_api_data_at": {
+          "name": "updated_api_data_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "admin": {
+          "name": "admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_host": {
+          "name": "approved_host",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "osu_user_id": {
+          "name": "osu_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(19)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "udx_user_osu_user_id": {
+          "name": "udx_user_osu_user_id",
+          "columns": [
+            "osu_user_id"
+          ],
+          "isUnique": true
+        },
+        "udx_user_discord_user_id": {
+          "name": "udx_user_discord_user_id",
+          "columns": [
+            "discord_user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_osu_user_id_osu_user_osu_user_id_fk": {
+          "name": "user_osu_user_id_osu_user_osu_user_id_fk",
+          "tableFrom": "user",
+          "tableTo": "osu_user",
+          "columnsFrom": [
+            "osu_user_id"
+          ],
+          "columnsTo": [
+            "osu_user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_discord_user_id_discord_user_discord_user_id_fk": {
+          "name": "user_discord_user_id_discord_user_discord_user_id_fk",
+          "tableFrom": "user",
+          "tableTo": "discord_user",
+          "columnsFrom": [
+            "discord_user_id"
+          ],
+          "columnsTo": [
+            "discord_user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uni_user_api_key": {
+          "name": "uni_user_api_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "api_key"
+          ]
+        }
+      }
+    },
+    "user_notification": {
+      "name": "user_notification",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_user_notification_notification_id": {
+          "name": "idx_user_notification_notification_id",
+          "columns": [
+            "notification_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_notification_user_id_notified_at": {
+          "name": "idx_user_notification_user_id_notified_at",
+          "columns": [
+            "user_id",
+            "notified_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_notification_user_id_user_id_fk": {
+          "name": "user_notification_user_id_user_id_fk",
+          "tableFrom": "user_notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_notification_notification_id_notification_id_fk": {
+          "name": "user_notification_notification_id_notification_id_fk",
+          "tableFrom": "user_notification",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_notification_user_id_notification_id_pk": {
+          "name": "user_notification_user_id_notification_id_pk",
+          "columns": [
+            "user_id",
+            "notification_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "round": {
+      "name": "round",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_star_rating": {
+          "name": "target_star_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playtesting_pool": {
+          "name": "playtesting_pool",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publish_pool": {
+          "name": "publish_pool",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publish_schedules": {
+          "name": "publish_schedules",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publish_stats": {
+          "name": "publish_stats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "round_stage_id_stage_id_fk": {
+          "name": "round_stage_id_stage_id_fk",
+          "tableFrom": "round",
+          "tableTo": "stage",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "round_tournament_id_tournament_id_fk": {
+          "name": "round_tournament_id_tournament_id_fk",
+          "tableFrom": "round",
+          "tableTo": "tournament",
+          "columnsFrom": [
+            "tournament_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uni_round_name_tournament_id": {
+          "name": "uni_round_name_tournament_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "tournament_id"
+          ]
+        }
+      }
+    },
+    "stage": {
+      "name": "stage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "stage_format",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_main_stage": {
+          "name": "is_main_stage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stage_tournament_id_tournament_id_fk": {
+          "name": "stage_tournament_id_tournament_id_fk",
+          "tableFrom": "stage",
+          "tableTo": "tournament",
+          "columnsFrom": [
+            "tournament_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uni_stage_tournament_id_format": {
+          "name": "uni_stage_tournament_id_format",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tournament_id",
+            "format"
+          ]
+        }
+      }
+    },
+    "tournament": {
+      "name": "tournament",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url_slug": {
+          "name": "url_slug",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acronym": {
+          "name": "acronym",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "tournament_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_metadata": {
+          "name": "logo_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_metadata": {
+          "name": "banner_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank_range": {
+          "name": "rank_range",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dates": {
+          "name": "dates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"other\":[]}'::jsonb"
+        },
+        "team_settings": {
+          "name": "team_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bws_values": {
+          "name": "bws_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "links": {
+          "name": "links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "referee_settings": {
+          "name": "referee_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"timerLength\":{\"pick\":120,\"ban\":120,\"protect\":120,\"ready\":120,\"start\":10},\"allow\":{\"doublePick\":false,\"doubleBan\":false,\"doubleProtect\":false},\"order\":{\"ban\":\"linear\",\"pick\":\"linear\",\"protect\":\"linear\"},\"alwaysForceNoFail\":true,\"banAndProtectCancelOut\":false,\"winCondition\":\"score\"}'::jsonb"
+        }
+      },
+      "indexes": {
+        "udx_tournament_url_slug": {
+          "name": "udx_tournament_url_slug",
+          "columns": [
+            "url_slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uni_tournament_name": {
+          "name": "uni_tournament_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "staff_member": {
+      "name": "staff_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "joined_staff_at": {
+          "name": "joined_staff_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "staff_member_user_id_user_id_fk": {
+          "name": "staff_member_user_id_user_id_fk",
+          "tableFrom": "staff_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staff_member_tournament_id_tournament_id_fk": {
+          "name": "staff_member_tournament_id_tournament_id_fk",
+          "tableFrom": "staff_member",
+          "tableTo": "tournament",
+          "columnsFrom": [
+            "tournament_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uni_staff_member_user_id_tournament_id": {
+          "name": "uni_staff_member_user_id_tournament_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "tournament_id"
+          ]
+        }
+      }
+    },
+    "staff_member_role": {
+      "name": "staff_member_role",
+      "schema": "",
+      "columns": {
+        "staff_member_id": {
+          "name": "staff_member_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staff_role_id": {
+          "name": "staff_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "staff_member_role_staff_member_id_staff_member_id_fk": {
+          "name": "staff_member_role_staff_member_id_staff_member_id_fk",
+          "tableFrom": "staff_member_role",
+          "tableTo": "staff_member",
+          "columnsFrom": [
+            "staff_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staff_member_role_staff_role_id_staff_role_id_fk": {
+          "name": "staff_member_role_staff_role_id_staff_role_id_fk",
+          "tableFrom": "staff_member_role",
+          "tableTo": "staff_role",
+          "columnsFrom": [
+            "staff_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "staff_member_role_staff_member_id_staff_role_id_pk": {
+          "name": "staff_member_role_staff_member_id_staff_role_id_pk",
+          "columns": [
+            "staff_member_id",
+            "staff_role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "staff_role": {
+      "name": "staff_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "staff_color",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'slate'"
+        },
+        "order": {
+          "name": "order",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "staff_permission[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": []
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "staff_role_tournament_id_tournament_id_fk": {
+          "name": "staff_role_tournament_id_tournament_id_fk",
+          "tableFrom": "staff_role",
+          "tableTo": "tournament",
+          "columnsFrom": [
+            "tournament_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uni_staff_role_name_tournament_id": {
+          "name": "uni_staff_role_name_tournament_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "tournament_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "staff_color": {
+      "name": "staff_color",
+      "values": {
+        "slate": "slate",
+        "gray": "gray",
+        "red": "red",
+        "orange": "orange",
+        "yellow": "yellow",
+        "lime": "lime",
+        "green": "green",
+        "emerald": "emerald",
+        "cyan": "cyan",
+        "blue": "blue",
+        "indigo": "indigo",
+        "purple": "purple",
+        "fuchsia": "fuchsia",
+        "pink": "pink"
+      }
+    },
+    "staff_permission": {
+      "name": "staff_permission",
+      "values": {
+        "host": "host",
+        "debug": "debug",
+        "manage_tournament": "manage_tournament",
+        "manage_assets": "manage_assets",
+        "manage_regs": "manage_regs",
+        "manage_pool_structure": "manage_pool_structure",
+        "view_pool_suggestions": "view_pool_suggestions",
+        "create_pool_suggestions": "create_pool_suggestions",
+        "delete_pool_suggestions": "delete_pool_suggestions",
+        "view_pooled_maps": "view_pooled_maps",
+        "manage_pooled_maps": "manage_pooled_maps",
+        "view_feedback": "view_feedback",
+        "can_playtest": "can_playtest",
+        "can_submit_replays": "can_submit_replays",
+        "view_matches": "view_matches",
+        "manage_matches": "manage_matches",
+        "ref_matches": "ref_matches",
+        "commentate_matches": "commentate_matches",
+        "stream_matches": "stream_matches",
+        "manage_stats": "manage_stats",
+        "can_play": "can_play"
+      }
+    },
+    "stage_format": {
+      "name": "stage_format",
+      "values": {
+        "groups": "groups",
+        "swiss": "swiss",
+        "qualifiers": "qualifiers",
+        "single_elim": "single_elim",
+        "double_elim": "double_elim",
+        "battle_royale": "battle_royale"
+      }
+    },
+    "tournament_type": {
+      "name": "tournament_type",
+      "values": {
+        "teams": "teams",
+        "draft": "draft",
+        "solo": "solo"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -78,6 +78,20 @@
       "when": 1710616033254,
       "tag": "0010_jazzy_inhumans",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "5",
+      "when": 1710889382647,
+      "tag": "0011_smart_red_wolf",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "5",
+      "when": 1710891168882,
+      "tag": "0012_square_the_watchers",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/server/db/registrations.ts
+++ b/src/lib/server/db/registrations.ts
@@ -7,7 +7,7 @@ import {
   timestamp,
   primaryKey
 } from 'drizzle-orm/pg-core';
-import { StaffColor, StaffPermission, Tournament, User  } from './schema';
+import { StaffColor, StaffPermission, Tournament, User } from './schema';
 import { timestampConfig, citext } from './schema-utils';
 
 export const StaffRole = pgTable(

--- a/src/lib/server/db/registrations.ts
+++ b/src/lib/server/db/registrations.ts
@@ -14,9 +14,7 @@ export const StaffRole = pgTable(
   'staff_role',
   {
     id: serial('id').primaryKey(),
-    name: citext('name', {
-      length: 45
-    }).notNull(),
+    name: citext('name').notNull(),
     color: StaffColor('color').notNull().default('slate'),
     order: smallint('order').notNull(),
     permissions: StaffPermission('permissions').array().notNull().default([]),

--- a/src/lib/server/db/registrations.ts
+++ b/src/lib/server/db/registrations.ts
@@ -1,21 +1,20 @@
 import {
   pgTable,
   serial,
-  varchar,
   integer,
   unique,
   smallint,
   timestamp,
   primaryKey
 } from 'drizzle-orm/pg-core';
-import { StaffColor, StaffPermission, Tournament, User } from './schema';
-import { timestampConfig } from './schema-utils';
+import { StaffColor, StaffPermission, Tournament, User  } from './schema';
+import { timestampConfig, citext } from './schema-utils';
 
 export const StaffRole = pgTable(
   'staff_role',
   {
     id: serial('id').primaryKey(),
-    name: varchar('name', {
+    name: citext('name', {
       length: 45
     }).notNull(),
     color: StaffColor('color').notNull().default('slate'),

--- a/src/lib/server/db/schema-utils.ts
+++ b/src/lib/server/db/schema-utils.ts
@@ -13,7 +13,7 @@ export const uniqueConstraints = {
   }
 } as const;
 
-export const citext = customType<{data: string}>({
+export const citext = customType<{ data: string }>({
   dataType() {
     return 'citext';
   }

--- a/src/lib/server/db/schema-utils.ts
+++ b/src/lib/server/db/schema-utils.ts
@@ -1,4 +1,4 @@
-import type { PgTimestampConfig } from 'drizzle-orm/pg-core';
+import { customType, type PgTimestampConfig } from 'drizzle-orm/pg-core';
 
 export const timestampConfig: PgTimestampConfig = {
   mode: 'date',
@@ -12,3 +12,9 @@ export const uniqueConstraints = {
     urlSlug: 'udx_tournament_url_slug'
   }
 } as const;
+
+export const citext = customType<{data: string}>({
+  dataType() {
+    return 'citext';
+  }
+});

--- a/src/lib/server/db/tournaments.ts
+++ b/src/lib/server/db/tournaments.ts
@@ -11,9 +11,9 @@ import {
   real,
   timestamp,
   uniqueIndex
-} from 'drizzle-orm/pg-core';
+}                                              from 'drizzle-orm/pg-core';
 import { StageFormat, TournamentType } from './schema';
-import { timestampConfig, uniqueConstraints } from './schema-utils';
+import { timestampConfig, uniqueConstraints, citext }  from './schema-utils';
 import type {
   BWSValues,
   RankRange,
@@ -30,7 +30,7 @@ export const Tournament = pgTable(
     id: serial('id').primaryKey(),
     createdAt: timestamp('created_at', timestampConfig).notNull().defaultNow(),
     deleted: boolean('deleted').notNull().default(false),
-    name: varchar('name', {
+    name: citext('name', {
       length: 50
     })
       .notNull()
@@ -115,7 +115,7 @@ export const Round = pgTable(
   'round',
   {
     id: serial('id').primaryKey(),
-    name: varchar('name', {
+    name: citext('name', {
       length: 20
     }).notNull(),
     order: smallint('order').notNull(),

--- a/src/lib/server/db/tournaments.ts
+++ b/src/lib/server/db/tournaments.ts
@@ -11,9 +11,9 @@ import {
   real,
   timestamp,
   uniqueIndex
-}                                              from 'drizzle-orm/pg-core';
+} from 'drizzle-orm/pg-core';
 import { StageFormat, TournamentType } from './schema';
-import { timestampConfig, uniqueConstraints, citext }  from './schema-utils';
+import { timestampConfig, uniqueConstraints, citext } from './schema-utils';
 import type {
   BWSValues,
   RankRange,

--- a/src/lib/server/db/tournaments.ts
+++ b/src/lib/server/db/tournaments.ts
@@ -30,9 +30,7 @@ export const Tournament = pgTable(
     id: serial('id').primaryKey(),
     createdAt: timestamp('created_at', timestampConfig).notNull().defaultNow(),
     deleted: boolean('deleted').notNull().default(false),
-    name: citext('name', {
-      length: 50
-    })
+    name: citext('name')
       .notNull()
       .unique(uniqueConstraints.tournament.name),
     urlSlug: varchar('url_slug', {
@@ -115,9 +113,7 @@ export const Round = pgTable(
   'round',
   {
     id: serial('id').primaryKey(),
-    name: citext('name', {
-      length: 20
-    }).notNull(),
+    name: citext('name').notNull(),
     order: smallint('order').notNull(),
     targetStarRating: real('target_star_rating').notNull(),
     playtestingPool: boolean('playtesting_pool').notNull().default(false),

--- a/src/lib/server/db/users.ts
+++ b/src/lib/server/db/users.ts
@@ -49,9 +49,7 @@ export const OsuUser = pgTable(
   'osu_user',
   {
     osuUserId: integer('osu_user_id').primaryKey(),
-    username: citext('username', {
-      length: 16
-    }).notNull(),
+    username: citext('username').notNull(),
     restricted: boolean('restricted').notNull(),
     globalStdRank: integer('global_std_rank'),
     token: jsonb('token').notNull().$type<OAuthToken>(),
@@ -113,9 +111,7 @@ export const DiscordUser = pgTable('discord_user', {
   discordUserId: varchar('discord_user_id', {
     length: 19
   }).primaryKey(),
-  username: citext('username', {
-    length: 32
-  }).notNull(),
+  username: citext('username').notNull(),
   token: jsonb('token').notNull().$type<OAuthToken>()
 });
 

--- a/src/lib/server/db/users.ts
+++ b/src/lib/server/db/users.ts
@@ -15,7 +15,7 @@ import {
   bigint,
   uniqueIndex
 } from 'drizzle-orm/pg-core';
-import { timestampConfig } from './schema-utils';
+import { timestampConfig, citext } from './schema-utils';
 import type { OAuthToken } from '$types';
 
 export const User = pgTable(
@@ -49,7 +49,7 @@ export const OsuUser = pgTable(
   'osu_user',
   {
     osuUserId: integer('osu_user_id').primaryKey(),
-    username: varchar('username', {
+    username: citext('username', {
       length: 16
     }).notNull(),
     restricted: boolean('restricted').notNull(),
@@ -113,7 +113,7 @@ export const DiscordUser = pgTable('discord_user', {
   discordUserId: varchar('discord_user_id', {
     length: 19
   }).primaryKey(),
-  username: varchar('username', {
+  username: citext('username', {
     length: 32
   }).notNull(),
   token: jsonb('token').notNull().$type<OAuthToken>()


### PR DESCRIPTION
Resolves #23 

This PR introduces `citext` custom type to our database schemas for further using and two new migrations, which add postgres `citext` extension and changes datatype of fields mentioned in the issue from `varchar`/`text` to `citext`.

Demonstration:
![image](https://github.com/Kyoso-Team/kyoso/assets/96246908/3bfe88cb-ce0d-4741-9d35-627bec166016)
![image](https://github.com/Kyoso-Team/kyoso/assets/96246908/223b4139-9d4b-41e1-bd1f-390fb99e61d0)
