### PR TITLE
Implemented main user/tournament search procedure

### DIFF
--- a/src/lib/server/procedures/tournaments.ts
+++ b/src/lib/server/procedures/tournaments.ts
@@ -15,7 +15,7 @@ import { wrap } from '@typeschema/valibot';
 import { getSession, getStaffMember } from '../helpers/trpc';
 import { TRPCError } from '@trpc/server';
 import { hasPermissions, keys } from '$lib/utils';
-import { asc, eq, ilike, or } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import {
   bwsValuesSchema,
   positiveIntSchema,
@@ -309,25 +309,8 @@ const deleteTournament = t.procedure
     }
   });
 
-// const searchTournaments = t.procedure.input(wrap(v.string())).query(async ({ input }) => {
-//   return db
-//     .select()
-//     .from(Tournament)
-//     .where(
-//       or(
-//         eq(Tournament.id, +input),
-//         ilike(Tournament.name, `%${input}%`),
-//         ilike(Tournament.acronym, `%${input}%`),
-//         ilike(Tournament.urlSlug, `%${input}%`),
-//         eq(Tournament.deleted, false)
-//       )
-//     )
-//     .orderBy(({ name }) => asc(name))
-//     .limit(10);
-// });
 export const tournamentsRouter = t.router({
   createTournament,
   updateTournament,
   deleteTournament
-  // searchTournaments
 });

--- a/src/lib/server/procedures/users.ts
+++ b/src/lib/server/procedures/users.ts
@@ -11,7 +11,7 @@ import {
   Session,
   User
 } from '$db';
-import { asc, ilike, notExists, type SQL } from 'drizzle-orm';
+import { type SQL } from 'drizzle-orm';
 import { and, desc, eq, isNull, not, or, sql } from 'drizzle-orm';
 import { t } from '$trpc';
 import { future, pick, trpcUnknownError } from '$lib/server/utils';
@@ -271,7 +271,7 @@ const updateUser = t.procedure
   )
   .mutation(async ({ ctx, input }) => {
     const { data, userId } = input;
-    const { admin } = data;
+    const { admin, approvedHost } = data;
     const session = getSession(ctx.cookies, true);
 
     if (admin !== undefined && session.osu.id !== env.OWNER) {
@@ -299,7 +299,10 @@ const updateUser = t.procedure
       await db.transaction(async (tx) => {
         await tx
           .update(User)
-          .set(data)
+          .set({
+            admin,
+            approvedHost
+          })
           .where(eq(User.id, userId));
 
         await tx
@@ -454,52 +457,6 @@ const expireSession = t.procedure
     }
   });
 
-// const newSearchUser = t.procedure.input(wrap(v.string())).query(async ({ ctx, input }) => {
-//   getSession(ctx.cookies, true);
-//
-//   try {
-//     const isBanned = db.$with('is_banned').as(
-//       db
-//         .select()
-//         .from(Ban)
-//         .where(
-//           notExists(
-//             sql`select 1
-//         from ${Ban}
-//         where ${and(
-//           eq(Ban.issuedToUserId, +input),
-//           and(isNull(Ban.revokedAt), or(isNull(Ban.liftAt), future(Ban.liftAt)))
-//         )}
-//         limit 1
-//     `
-//           )
-//         )
-//     );
-//
-//     return await db
-//       .with(isBanned)
-//       .select({
-//         id: User.id,
-//         osuId: User.osuUserId,
-//         username: OsuUser.username
-//       })
-//       .from(User)
-//       .leftJoin(OsuUser, eq(User.osuUserId, OsuUser.osuUserId))
-//       .where(
-//         or(
-//           eq(User.id, +input),
-//           eq(User.osuUserId, +input),
-//           eq(User.discordUserId, input),
-//           ilike(OsuUser.username, `%${input}%`)
-//         )
-//       )
-//       .orderBy(({ username }) => asc(username))
-//       .limit(10);
-//   } catch (err) {
-//     throw trpcUnknownError(err, 'Expiring the session');
-//   }
-// });
-
 export const usersRouter = t.router({
   getUser,
   searchUser,
@@ -508,5 +465,4 @@ export const usersRouter = t.router({
   banUser,
   revokeBan,
   expireSession
-  // newSearchUser
 });

--- a/src/lib/server/trpc/router.ts
+++ b/src/lib/server/trpc/router.ts
@@ -2,9 +2,9 @@ import * as v from 'valibot';
 import { t } from '$trpc';
 import { notificationsRouter, tournamentsRouter, usersRouter } from '../procedures';
 import { wrap } from '@typeschema/valibot';
-import { getSession } from '$lib/server/helpers/api';
+import { getSession } from '$lib/server/helpers/trpc';
 import { Ban, db, OsuUser, Tournament, User } from '$db';
-import { and, asc, eq, ilike, isNull, or, type SQL, sql } from 'drizzle-orm';
+import { and, asc, eq, ilike, isNull, notExists, or, type SQL, sql } from 'drizzle-orm';
 import { future, pick, trpcUnknownError } from '$lib/server/utils';
 
 const search = t.procedure.input(wrap(v.string())).query(async ({ ctx, input }) => {
@@ -50,7 +50,7 @@ const search = t.procedure.input(wrap(v.string())).query(async ({ ctx, input }) 
       })
       .from(User)
       .innerJoin(OsuUser, eq(User.osuUserId, OsuUser.osuUserId))
-      .where(or(...userWhereCondition))
+      .where(and(notExists(isBanned), or(...userWhereCondition)))
       .orderBy(asc(OsuUser.username))
       .limit(10);
   } catch (err) {

--- a/src/lib/server/trpc/router.ts
+++ b/src/lib/server/trpc/router.ts
@@ -1,7 +1,98 @@
-import { usersRouter, tournamentsRouter, notificationsRouter } from '../procedures';
+import * as v from 'valibot';
 import { t } from '$trpc';
+import { notificationsRouter, tournamentsRouter, usersRouter } from '../procedures';
+import { wrap } from '@typeschema/valibot';
+import { getSession } from '$lib/server/helpers/api';
+import { Ban, db, OsuUser, Tournament, User } from '$db';
+import { and, asc, eq, ilike, isNull, notExists, or, sql } from 'drizzle-orm';
+import { future, pick, trpcUnknownError } from '$lib/server/utils';
+
+const search = t.procedure.input(wrap(v.string())).query(async ({ ctx, input }) => {
+  getSession(ctx.cookies, true);
+
+  let users:
+    | (Pick<typeof User.$inferSelect, 'id' | 'osuUserId'> & {
+        username: string;
+      })[]
+    | undefined;
+
+  try {
+    const isBanned = db.$with('is_banned').as(
+      db
+        .select()
+        .from(Ban)
+        .where(
+          notExists(
+            sql`select 1
+                from ${Ban}
+                where ${and(
+                  eq(Ban.issuedToUserId, +input),
+                  and(isNull(Ban.revokedAt), or(isNull(Ban.liftAt), future(Ban.liftAt)))
+                )}
+                limit 1
+            `
+          )
+        )
+    );
+
+    users = await db
+      .with(isBanned)
+      .select({
+        ...pick(User, ['id', 'osuUserId']),
+        username: OsuUser.username
+      })
+      .from(User)
+      .innerJoin(OsuUser, eq(User.osuUserId, OsuUser.osuUserId))
+      .where(
+        or(
+          eq(User.id, +input),
+          eq(User.osuUserId, +input),
+          eq(User.discordUserId, input),
+          ilike(OsuUser.username, `%${input}%`)
+        )
+      )
+      .orderBy(({ username }) => asc(username))
+      .limit(10);
+  } catch (err) {
+    throw trpcUnknownError(err, 'Expiring the session');
+  }
+
+  let tournaments:
+    | Pick<
+        typeof Tournament.$inferSelect,
+        'name' | 'urlSlug' | 'acronym' | 'logoMetadata' | 'bannerMetadata'
+      >[]
+    | undefined;
+
+  try {
+    tournaments = await db
+      .select({
+        ...pick(Tournament, ['name', 'urlSlug', 'acronym', 'logoMetadata', 'bannerMetadata'])
+      })
+      .from(Tournament)
+      .where(
+        or(
+          eq(Tournament.id, +input),
+          ilike(Tournament.name, `%${input}%`),
+          ilike(Tournament.acronym, `%${input}%`),
+          ilike(Tournament.urlSlug, `%${input}%`),
+          eq(Tournament.deleted, false)
+        )
+      )
+      .orderBy(({ name }) => asc(name))
+      .limit(10);
+  } catch (err) {
+    throw trpcUnknownError(err, 'Expiring the session');
+  }
+
+  return {
+    users,
+    tournaments
+  };
+});
 
 export const router = t.router({
+  search,
   users: usersRouter,
   tournaments: tournamentsRouter,
   notifications: notificationsRouter


### PR DESCRIPTION
Resolves #26 

This PR introduces new procedure to search for users/tournaments similarly to how search works on osu website (searching for users/beatmaps from one query input)