### PR TITLE
Create API route to upload a tournament's logo

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -136,4 +136,13 @@ export interface Assets {
       tournamentId: number;
     }
   >;
+  tournamentLogo: Asset<
+    {
+      file: File;
+      tournamentId: number;
+    },
+    {
+      tournamentId: number;
+    }
+  >;
 }


### PR DESCRIPTION
Addresses #25.

Updated the endpoint that manages the tournament's banner and then just mirrored everything for the tournament's logo since they're the same implementation wise. I also added a little bit more type safety to these API routes (API routes were decided since tRPC doesn't support form data).