### PR TITLE
Update `updateTournament` procedure and simplify backend checks

### DIFF
--- a/src/lib/server/helpers/checks.ts
+++ b/src/lib/server/helpers/checks.ts
@@ -84,8 +84,10 @@ export class TRPCChecks extends Checks<TRPC_ERROR_CODE_KEY> {
   /**
    * @param action Description of the action performed in the backend. Usually written as: {infitive verb} {thing}. Example: "update this tournament" which would result in an error message like "You do not have the required staff permissions to update this tournament"
    */
-  constructor(action: string) {
-    super(action, true, {
+  constructor(settings: {
+    action: string;
+  }) {
+    super(settings.action, true, {
       badRequest: 'BAD_REQUEST',
       unauthorized: 'UNAUTHORIZED',
       forbidden: 'FORBIDDEN'
@@ -97,8 +99,10 @@ export class APICheck extends Checks<number> {
   /**
    * @param action Description of the action performed in the backend. Usually written as: {infitive verb} {thing}. Example: "update this tournament" which would result in an error message like "You do not have the required staff permissions to update this tournament"
    */
-  constructor(action: string) {
-    super(action, false, {
+  constructor(settings: {
+    action: string;
+  }) {
+    super(settings.action, false, {
       badRequest: 400,
       unauthorized: 401,
       forbidden: 403

--- a/src/lib/server/helpers/checks.ts
+++ b/src/lib/server/helpers/checks.ts
@@ -1,0 +1,107 @@
+import { hasPermissions } from '$lib/utils';
+import { isDatePast } from '../utils';
+import { error } from '@sveltejs/kit';
+import { TRPCError } from '@trpc/server';
+import type { AuthSession, InferEnum } from '$types';
+import type { StaffPermission } from '$db';
+import type { TRPC_ERROR_CODE_KEY } from '@trpc/server/rpc';
+
+abstract class Checks<ErrCodeT = number | TRPC_ERROR_CODE_KEY> {
+  constructor(
+    protected action: string,
+    protected trpc: boolean,
+    protected codes: Record<'unauthorized' | 'badRequest' | 'forbidden', ErrCodeT>
+  ) {}
+
+  private error(code: ErrCodeT, message: string) {
+    if (this.trpc) {
+      throw new TRPCError({
+        code: code as any,
+        message
+      });
+    }
+
+    error(code as any, message);
+  }
+
+  /**
+   * Error if a partial (an object with all of its properties being optional) doesn't have at least one property
+   */
+  public partialHasValues(data: Record<string, any> | undefined) {
+    if (Object.keys(data || {}).length > 0) return this;
+    throw this.error(this.codes.badRequest, 'Nothing to update');
+  }
+
+  /**
+   * Error if the user is not an admin
+   */
+  public userIsAdmin(session: AuthSession) {
+    if (session.admin) return this;
+    throw this.error(this.codes.unauthorized, `You must be a website admin to ${this.action}`);
+  }
+
+
+  /**
+   * Error if the user is not an approved host
+   */
+  public userIsApprovedHost(session: AuthSession) {
+    if (session.approvedHost) return this;
+    throw this.error(this.codes.unauthorized, `You must be an approved host to ${this.action}`);
+  }
+
+  /**
+   * Error if the staff member does not have the required permissions
+   */
+  public staffHasPermissions(
+    staffMember: { permissions: InferEnum<typeof StaffPermission>[] },
+    requiredPerms: InferEnum<typeof StaffPermission>[]
+  ) {
+    if (hasPermissions(staffMember, requiredPerms)) return this;
+    throw this.error(
+      this.codes.unauthorized,
+      `You do not have the required staff permissions to ${this.action}`
+    );
+  }
+
+  /**
+   * Error if the tournament is deleted
+   */
+  public tournamentNotDeleted(tournament: { deleted: boolean }) {
+    if (!tournament.deleted) return this;
+    throw this.error(this.codes.forbidden, `This tournament is deleted. You can't ${this.action}`);
+  }
+
+  /**
+   * Error if the tournament has concluded
+   */
+  public tournamentNotConcluded(tournament: { concludesAt: Date | null }) {
+    if (!isDatePast(tournament.concludesAt)) return this;
+    throw this.error(this.codes.forbidden, `This tournament has concluded. You can't ${this.action}`);
+  }
+}
+
+export class TRPCChecks extends Checks<TRPC_ERROR_CODE_KEY> {
+  /**
+   * @param action Description of the action performed in the backend. Usually written as: {infitive verb} {thing}. Example: "update this tournament" which would result in an error message like "You do not have the required staff permissions to update this tournament"
+   */
+  constructor(action: string) {
+    super(action, true, {
+      badRequest: 'BAD_REQUEST',
+      unauthorized: 'UNAUTHORIZED',
+      forbidden: 'FORBIDDEN'
+    });
+  }
+}
+
+export class APICheck extends Checks<number> {
+  /**
+   * @param action Description of the action performed in the backend. Usually written as: {infitive verb} {thing}. Example: "update this tournament" which would result in an error message like "You do not have the required staff permissions to update this tournament"
+   */
+  constructor(action: string) {
+    super(action, false, {
+      badRequest: 400,
+      unauthorized: 401,
+      forbidden: 403
+    });
+  }
+}

--- a/src/lib/server/procedures/tournaments.ts
+++ b/src/lib/server/procedures/tournaments.ts
@@ -63,7 +63,7 @@ const createTournament = t.procedure
   .input(wrap(v.object(mutationSchemas)))
   .mutation(async ({ ctx, input }) => {
     const { teamSettings } = input;
-    const checks = new TRPCChecks('create a tournament');
+    const checks = new TRPCChecks({ action: 'create a tournament' });
     const session = getSession(ctx.cookies, true);
     checks.userIsApprovedHost(session);
 
@@ -178,7 +178,7 @@ const updateTournament = t.procedure
   .mutation(async ({ ctx, input }) => {
     const { data, tournamentId } = input;
     const { tournament, dates } = data;
-    const checks = new TRPCChecks('update this tournament');
+    const checks = new TRPCChecks({ action: 'update this tournament' });
     checks.partialHasValues(tournament).partialHasValues(dates);
 
     const session = getSession(ctx.cookies, true);
@@ -333,7 +333,7 @@ const deleteTournament = t.procedure
   )
   .mutation(async ({ ctx, input }) => {
     const { tournamentId } = input;
-    const checks = new TRPCChecks('delete this tournament');
+    const checks = new TRPCChecks({ action: 'delete this tournament' });
     const session = getSession(ctx.cookies, true);
     const staffMember = await getStaffMember(session, tournamentId, true);
     checks.staffHasPermissions(staffMember, ['host']);

--- a/src/lib/server/procedures/users.ts
+++ b/src/lib/server/procedures/users.ts
@@ -22,8 +22,10 @@ import { getSession } from '../helpers/api';
 import { TRPCError } from '@trpc/server';
 import { alias, unionAll } from 'drizzle-orm/pg-core';
 import { rateLimitMiddleware } from '$trpc/middleware';
+import { TRPCChecks } from '../helpers/checks';
 
 const getUser = t.procedure
+  .use(rateLimitMiddleware)
   .input(
     wrap(
       v.object({
@@ -33,14 +35,9 @@ const getUser = t.procedure
   )
   .query(async ({ ctx, input }) => {
     const { userId } = input;
+    const checks = new TRPCChecks('get this user');
     const session = getSession(ctx.cookies, true);
-
-    if (!session.admin) {
-      throw new TRPCError({
-        code: 'UNAUTHORIZED',
-        message: 'You do not have the required permissions to get this user'
-      });
-    }
+    checks.userIsAdmin(session);
 
     let user!: Pick<
       typeof User.$inferSelect,
@@ -192,14 +189,9 @@ const searchUser = t.procedure
   )
   .query(async ({ ctx, input }) => {
     const { search, searchBy } = input;
+    const checks = new TRPCChecks('search this user');
     const session = getSession(ctx.cookies, true);
-
-    if (!session.admin) {
-      throw new TRPCError({
-        code: 'UNAUTHORIZED',
-        message: 'You do not have the required permissions to search this user'
-      });
-    }
+    checks.userIsAdmin(session);
 
     const searchNum = isNaN(Number(search)) ? 0 : Number(search);
     let where!: SQL;
@@ -231,7 +223,7 @@ const searchUser = t.procedure
     return user;
   });
 
-const updateSelf = t.procedure.mutation(async ({ ctx }) => {
+const updateSelf = t.procedure.use(rateLimitMiddleware).mutation(async ({ ctx }) => {
   const session = getSession(ctx.cookies, true);
 
   let user!: Pick<typeof User.$inferSelect, 'apiKey'>;
@@ -256,6 +248,7 @@ const updateSelf = t.procedure.mutation(async ({ ctx }) => {
 });
 
 const updateUser = t.procedure
+  .use(rateLimitMiddleware)
   .input(
     wrap(
       v.object({
@@ -272,26 +265,14 @@ const updateUser = t.procedure
   .mutation(async ({ ctx, input }) => {
     const { data, userId } = input;
     const { admin, approvedHost } = data;
+    const checks = new TRPCChecks('update this user');
     const session = getSession(ctx.cookies, true);
+    checks.userIsAdmin(session).partialHasValues(data);
 
     if (admin !== undefined && session.osu.id !== env.OWNER) {
       throw new TRPCError({
         code: 'UNAUTHORIZED',
         message: 'You do not have the required permissions to remove or add this user as an admin'
-      });
-    }
-
-    if (!session.admin) {
-      throw new TRPCError({
-        code: 'UNAUTHORIZED',
-        message: 'You do not have the required permissions update this user'
-      });
-    }
-
-    if (Object.keys(data).length === 0) {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: 'Nothing to update'
       });
     }
 
@@ -318,6 +299,7 @@ const updateUser = t.procedure
   });
 
 const banUser = t.procedure
+  .use(rateLimitMiddleware)
   .input(
     wrap(
       v.object({
@@ -330,14 +312,9 @@ const banUser = t.procedure
   )
   .mutation(async ({ ctx, input }) => {
     const { banReason, banTime, issuedToUserId } = input;
+    const checks = new TRPCChecks('ban this user');
     const session = getSession(ctx.cookies, true);
-
-    if (!session.admin) {
-      throw new TRPCError({
-        code: 'UNAUTHORIZED',
-        message: 'You do not have the required permissions to ban this user'
-      });
-    }
+    checks.userIsAdmin(session);
 
     let hasActiveBan!: boolean;
 
@@ -401,6 +378,7 @@ const banUser = t.procedure
   });
 
 const revokeBan = t.procedure
+  .use(rateLimitMiddleware)
   .input(
     wrap(
       v.object({
@@ -411,14 +389,9 @@ const revokeBan = t.procedure
   )
   .mutation(async ({ ctx, input }) => {
     const { banId, revokeReason } = input;
+    const checks = new TRPCChecks('revoke this ban');
     const session = getSession(ctx.cookies, true);
-
-    if (!session.admin) {
-      throw new TRPCError({
-        code: 'UNAUTHORIZED',
-        message: 'You do not have the required permissions to revoke this ban'
-      });
-    }
+    checks.userIsAdmin(session);
 
     try {
       await db
@@ -435,6 +408,7 @@ const revokeBan = t.procedure
   });
 
 const expireSession = t.procedure
+  .use(rateLimitMiddleware)
   .input(
     wrap(
       v.object({

--- a/src/lib/server/procedures/users.ts
+++ b/src/lib/server/procedures/users.ts
@@ -35,7 +35,7 @@ const getUser = t.procedure
   )
   .query(async ({ ctx, input }) => {
     const { userId } = input;
-    const checks = new TRPCChecks('get this user');
+    const checks = new TRPCChecks({ action: 'get this user' });
     const session = getSession(ctx.cookies, true);
     checks.userIsAdmin(session);
 
@@ -189,7 +189,7 @@ const searchUser = t.procedure
   )
   .query(async ({ ctx, input }) => {
     const { search, searchBy } = input;
-    const checks = new TRPCChecks('search this user');
+    const checks = new TRPCChecks({ action: 'search this user' });
     const session = getSession(ctx.cookies, true);
     checks.userIsAdmin(session);
 
@@ -265,7 +265,7 @@ const updateUser = t.procedure
   .mutation(async ({ ctx, input }) => {
     const { data, userId } = input;
     const { admin, approvedHost } = data;
-    const checks = new TRPCChecks('update this user');
+    const checks = new TRPCChecks({ action: 'update this user' });
     const session = getSession(ctx.cookies, true);
     checks.userIsAdmin(session).partialHasValues(data);
 
@@ -312,7 +312,7 @@ const banUser = t.procedure
   )
   .mutation(async ({ ctx, input }) => {
     const { banReason, banTime, issuedToUserId } = input;
-    const checks = new TRPCChecks('ban this user');
+    const checks = new TRPCChecks({ action: 'ban this user' });
     const session = getSession(ctx.cookies, true);
     checks.userIsAdmin(session);
 
@@ -389,7 +389,7 @@ const revokeBan = t.procedure
   )
   .mutation(async ({ ctx, input }) => {
     const { banId, revokeReason } = input;
-    const checks = new TRPCChecks('revoke this ban');
+    const checks = new TRPCChecks({ action: 'revoke this ban' });
     const session = getSession(ctx.cookies, true);
     checks.userIsAdmin(session);
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,6 +11,7 @@ import type {
   tournamentOtherDatesSchema,
   tournamentLinkSchema
 } from './schemas';
+import type { Tournament, TournamentDates } from '$db';
 
 export type AnyComponent = any;
 
@@ -37,6 +38,8 @@ export type TournamentOtherDates = Output<typeof tournamentOtherDatesSchema>;
 export type RankRange = Output<typeof rankRangeSchema>;
 
 export type RoundConfig = StandardRoundConfig | QualifierRoundConfig | BattleRoyaleRoundConfig;
+
+export type FullTournament = typeof Tournament.$inferSelect & Omit<typeof TournamentDates.$inferSelect, 'tournamentId'>;
 
 /** Applies to: Groups, swiss, single and double elim. */
 export interface StandardRoundConfig {


### PR DESCRIPTION
This PR updates the `updateTournament` tRPC procedure to match the specifications described in #48. I've also made a `Checks` class that simplifies common checks.

Example of these checks:

```ts
// before
if (!hasPermissions(staffMember, ['host', 'debug', 'manage_tournament'])) {
  throw new TRPCError({
    code: 'UNAUTHORIZED',
    message: 'You do not have the required permissions to update this tournament'
  });
}

// after
checks.staffHasPermissions(staffMember, ['host', 'debug', 'manage_tournament']);
```

When using in tRPC procedures, use `TRPCChecks`; when using in API routes, use `APIChecks`.